### PR TITLE
Fix PHP notice "undefined variable"

### DIFF
--- a/footnotes-made-easy.php
+++ b/footnotes-made-easy.php
@@ -284,9 +284,9 @@ class swas_wp_footnotes {
 				$footnotes_markup = $footnotes_markup . '</li>';
 			}
 			$footnotes_markup = $footnotes_markup . '</ol>' . $this->current_options[ 'post_footnotes' ];
+			
+			$data = $data . $footnotes_markup;
 		}
-
-		$data = $data . $footnotes_markup;
 
 		return $data;
 	}


### PR DESCRIPTION
We're having this notice at some points; 
`Notice: Undefined variable: footnotes_markup in /footnotes-made-easy/footnotes-made-easy.php on line 289`